### PR TITLE
Use Ruff for linting and formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,0 @@
-[flake8]
-max-line-length = 88
-
-max-complexity = 10
-
-extend-ignore =
-	# Black creates whitespace before colon
-	E203

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,18 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
     - id: end-of-file-fixer
     - id: trailing-whitespace
       args:
       - "--markdown-linebreak-ext=md"
--   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.5
     hooks:
-    - id: flake8
--   repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-    - id: black
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
-    hooks:
-    - id: isort
+    - id: ruff-format
+    - id: ruff
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v1.6.1
     hooks:
     -   id: mypy
         args: []  # If not specified, pre-commit will run mypy with `--ignore-missing-imports`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,16 +37,17 @@ packages = ["slackstatus"]
 
 [tool.setuptools_scm]
 
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 88
-known_first_party = 'slackstatus'
-known_shared = ''
-sections = 'FUTURE,STDLIB,THIRDPARTY,SHARED,FIRSTPARTY,LOCALFOLDER'
-default_section = 'THIRDPARTY'
+[tool.ruff]
+fix = true
+show-fixes = true
+select = ["F", "E", "W", "I", "UP", "RUF", "C90"]
+unfixable = [
+    # Ruff fixes unused variables by deleting them, which can be annoying if you format on save.
+    "F841", "F842",
+]
+
+[tool.ruff.isort]
+known-first-party = ["slackstatus"]
 
 [tool.mypy]
 warn_redundant_casts = true
@@ -64,7 +65,6 @@ omit = [
 ]
 
 [tool.coverage.report]
-exclude_lines = [
-    'pragma: no cover',
-    'if __name__ == "__main__":'
+exclude_also = [
+    'if __name__ == "__main__":',
 ]


### PR DESCRIPTION
Now that the Ruff formatter is stable, use it to replace the current combination of Flake8 (linting), isort (import sorting) and Black (code formatting).